### PR TITLE
chore: Add dry-run option to deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 # Deploy portfolio site to Cloudflare Pages
-# Usage: ./deploy.sh [branch]
+# Usage: ./deploy.sh [--dry-run] [branch]
 # Examples:
 #   ./deploy.sh              # deploys current branch
 #   ./deploy.sh main         # deploys from main branch
-#   ./deploy.sh build-site   # deploys from build-site branch
+#   ./deploy.sh --dry-run    # build only, show what would be deployed
+#   ./deploy.sh --dry-run main
 
 set -euo pipefail
 
 PROJECT_NAME="graham-nessler-portfolio"
 PORTFOLIO_DIR="portfolio"
+DRY_RUN=false
+
+# Parse flags
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
 
 # Determine branch
 if [ -n "${1:-}" ]; then
@@ -26,6 +36,22 @@ echo "Building site..."
 cd "$PORTFOLIO_DIR"
 npm install --silent
 npx astro build
+
+if [ "$DRY_RUN" = true ]; then
+  echo ""
+  echo "=== DRY RUN ==="
+  echo "Would deploy to Cloudflare Pages:"
+  echo "  Project: $PROJECT_NAME"
+  echo "  Branch:  $BRANCH"
+  echo "  Source:   $(pwd)/dist/"
+  echo "  Command:  wrangler pages deploy dist --project-name=\"$PROJECT_NAME\" --branch=\"$BRANCH\""
+  echo ""
+  echo "Files that would be deployed:"
+  find dist -type f | sort
+  echo ""
+  echo "Dry run complete. No files were deployed."
+  exit 0
+fi
 
 # Deploy
 echo "Deploying to Cloudflare Pages..."

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.1",


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to `deploy.sh` that builds the site and shows what would be deployed without actually deploying
- Updates `package-lock.json` from dependency install

## Test plan
- [x] `./deploy.sh --dry-run` builds and shows deploy preview without deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)